### PR TITLE
Config Injection

### DIFF
--- a/src/Config/Services.php
+++ b/src/Config/Services.php
@@ -29,6 +29,6 @@ class Services extends BaseService
             return static::getSharedInstance('settings');
         }
 
-        return new Settings();
+        return new Settings(config('Settings'));
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,6 +2,8 @@
 
 namespace Sparks\Settings;
 
+use Sparks\Settings\Config\Settings as SettingsConfig;
+
 /**
  * Allows developers a single location to store and
  * retrieve settings that were original set in config files
@@ -27,10 +29,13 @@ class Settings
     /**
      * Grabs instances of our handlers.
      */
-    public function __construct()
+    public function __construct(?SettingsConfig $config = null)
     {
-        foreach (config('Settings')->handlers as $handler) {
-            $class = config('Settings')->{$handler}['class'] ?? null;
+        /** @var SettingsConfig $config */
+        $config = $config ?? config('Settings');
+
+        foreach ($config->handlers as $handler) {
+            $class = $config->{$handler}['class'] ?? null;
 
             if ($class === null) {
                 continue;
@@ -38,7 +43,7 @@ class Settings
 
             $this->handlers[$handler] = new $class();
 
-            $writeable = config('Settings')->{$handler}['writeable'] ?? null;
+            $writeable = $config->{$handler}['writeable'] ?? null;
 
             if ($writeable) {
                 $this->writeHandler = $handler;

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -16,6 +16,17 @@ final class SettingsTest extends TestCase
 {
     use DatabaseTestTrait;
 
+    public function testSettingsUsesParameter()
+    {
+        $config           = config('Settings');
+        $config->handlers = [];
+
+        $settings = new Settings($config);
+        $result   = $this->getPrivateProperty($settings, 'handlers');
+
+        $this->assertSame([], $result);
+    }
+
     public function testSettingsGetsFromConfig()
     {
         $settings = new Settings();


### PR DESCRIPTION
A nod towards DI and to ease extending the actual class, this PR adds a parameter for the Config file to be used to make handler definition easier. I think ideally this parameter would be required and the service would handle the config fallback, but that BC will have to wait for version 2.