### PR TITLE
Contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ $theme = service('setting')->get('App.theme', $context);
 setting()->get('App.theme', $context);
 ```
 
-If that context is not found the library falls back to the general value, i.e. `service('setting')->get('App.theme')`
+Contexts are a cascading check, so if a context does not match a value it will fall back on general,
+i.e. `service('setting')->get('App.theme')`. Return value priority is as follows:
+"Setting with a context > Setting without context > Config value > null".
 
 ### Using the Helper
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,34 @@ it effectively resets itself back to the default value in config file, if any.
 service('setting')->forget('App.siteName')
 ```
 
+### Contextual Settings
+
+In addition to the default behavior describe above, `Settings` can can be used to define "contextual settings".
+A context may be anything you want, but common examples are a runtime environment or an authenticated user.
+In order to use a context you pass it as an additional parameter to the `get()`/`set()`/`forget()` methods; if
+a context setting is requested and does not exist then the default global value will be used.
+
+Contexts may be any unique string you choose, but a recommended format for supplying some consistency is to
+given them a category and identifier, like `environment:production` or `group:42`.
+
+An example... Say your App config includes the name of a theme to use to enhance your display. By default
+your config file specifies `App.theme = 'default'`. When a user changes their theme, you do not want this to
+change the theme for all visitors to the site, so you need to provide the user as the *context* for the change:
+
+```php
+	$context = 'user:' . user_id();
+	service('setting')->set('App.theme', 'dark', $context);
+```
+
+Now when your filter is determining which theme to apply it can check for the current user as the context:
+
+```php
+	$context = 'user:' . user_id();
+	$theme = service('setting')->get('App.theme', $context);
+```
+
+If that context is not found the library falls back to the global value, i.e. `service('setting')->get('App.theme')`
+
 ### Using the Helper
 
 The helper provides a shortcut to the using the service. It must first be loaded using the `helper()` method
@@ -99,6 +127,8 @@ setting()->set('App.siteName', 'My Great Site');
 // Forgetting a value
 setting()->forget('App.siteName');
 ```
+
+> Note: Due to the shorthand nature of the helper function it cannot access contextual settings.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -85,28 +85,31 @@ service('setting')->forget('App.siteName')
 In addition to the default behavior describe above, `Settings` can can be used to define "contextual settings".
 A context may be anything you want, but common examples are a runtime environment or an authenticated user.
 In order to use a context you pass it as an additional parameter to the `get()`/`set()`/`forget()` methods; if
-a context setting is requested and does not exist then the default global value will be used.
+a context setting is requested and does not exist then the general value will be used.
 
 Contexts may be any unique string you choose, but a recommended format for supplying some consistency is to
-given them a category and identifier, like `environment:production` or `group:42`.
+give them a category and identifier, like `environment:production` or `group:42`.
 
 An example... Say your App config includes the name of a theme to use to enhance your display. By default
 your config file specifies `App.theme = 'default'`. When a user changes their theme, you do not want this to
 change the theme for all visitors to the site, so you need to provide the user as the *context* for the change:
 
 ```php
-	$context = 'user:' . user_id();
-	service('setting')->set('App.theme', 'dark', $context);
+$context = 'user:' . user_id();
+service('setting')->set('App.theme', 'dark', $context);
 ```
 
 Now when your filter is determining which theme to apply it can check for the current user as the context:
 
 ```php
-	$context = 'user:' . user_id();
-	$theme = service('setting')->get('App.theme', $context);
+$context = 'user:' . user_id();
+$theme = service('setting')->get('App.theme', $context);
+
+// or using the helper
+setting()->get('App.theme', $context);
 ```
 
-If that context is not found the library falls back to the global value, i.e. `service('setting')->get('App.theme')`
+If that context is not found the library falls back to the general value, i.e. `service('setting')->get('App.theme')`
 
 ### Using the Helper
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,6 @@
+# Upgrade Guide
+
+## Version 1 to 2
+***
+
+* Due to the addition of contexts the `BaseHandler` abstract class was changed. Update any handlers that extend this class to include the new and changed methods.

--- a/src/Database/Migrations/2021-11-14-143905_AddContextColumn.php
+++ b/src/Database/Migrations/2021-11-14-143905_AddContextColumn.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sparks\Settings\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddContextColumn extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn(config('Settings')->database['table'], [
+            'context' => [
+                'type'       => 'varchar',
+                'constraint' => 255,
+                'null'       => true,
+                'after'      => 'type',
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        $this->forge->dropColumn(config('Settings')->database['table'], 'context');
+    }
+}

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -2,14 +2,21 @@
 
 namespace Sparks\Settings\Handlers;
 
+use RuntimeException;
+
 abstract class BaseHandler
 {
+    /**
+     * Checks whether this handler has a value set.
+     */
+    abstract public function has(string $class, string $property, ?string $context = null): bool;
+
     /**
      * Returns a single value from the handler, if stored.
      *
      * @return mixed
      */
-    abstract public function get(string $class, string $property);
+    abstract public function get(string $class, string $property, ?string $context = null);
 
     /**
      * If the Handler supports saving values, it
@@ -18,11 +25,27 @@ abstract class BaseHandler
      *
      * @param mixed $value
      *
+     * @throws RuntimeException
+     *
      * @return mixed
      */
-    public function set(string $class, string $property, $value = null)
+    public function set(string $class, string $property, $value = null, ?string $context = null)
     {
-        throw new \RuntimeException('Set method not implemented for current Settings handler.');
+        throw new RuntimeException('Set method not implemented for current Settings handler.');
+    }
+
+    /**
+     * If the Handler supports forgetting values, it
+     * MUST override this method to provide that functionality.
+     * Not all Handlers will support writing values.
+     *
+     * @throws RuntimeException
+     *
+     * @return mixed
+     */
+    public function forget(string $class, string $property, ?string $context = null)
+    {
+        throw new RuntimeException('Forget method not implemented for current Settings handler.');
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -69,7 +69,7 @@ class Settings
             }
         }
 
-        // If no contextual value was found then fall back on a global
+        // If no contextual value was found then fall back to general
         if ($context !== null) {
             return $this->get($key);
         }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -28,7 +28,8 @@ final class HelperTest extends TestCase
 
     public function testThrowsExceptionWithInvalidField()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('$key must contain both the class and field name, i.e. Foo.bar');
 
         setting('Foobar');
     }


### PR DESCRIPTION
This PR expands the core function to add a new feature: contexts. A "contextual setting" is a way of defining a setting for a specific subset of circumstances, left to the developer to define (see https://github.com/codeigniter4/settings/pull/15#issuecomment-968101752). Contextual settings fall back on their "global" version (i.e. the current behavior), providing one more layer of customizability. An example of a contextual setting might be environment-specific URLs:

```php
service('Settings')->set('App.homepage', '/welcome', 'environment:production');
service('Settings')->set('App.homepage', '/debug', 'environment:development');
```

In order to facilitate detection of "hits" versus "misses" this PR also adds the `has()` method to handlers to determine whether a value is present or not. This expands on `null` value support, since we can now differentiate between "nonexistent" and "present but null".

*Note: Because this feature modifies an abstract method definition it will require a major release.*