### PR TITLE
Multiple Write Handlers

### DIFF
--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -22,12 +22,13 @@ abstract class BaseHandler
      * If the Handler supports saving values, it
      * MUST override this method to provide that functionality.
      * Not all Handlers will support writing values.
+     * Must throw RuntimeException for any failures.
      *
      * @param mixed $value
      *
      * @throws RuntimeException
      *
-     * @return mixed
+     * @return void
      */
     public function set(string $class, string $property, $value = null, ?string $context = null)
     {
@@ -38,10 +39,11 @@ abstract class BaseHandler
      * If the Handler supports forgetting values, it
      * MUST override this method to provide that functionality.
      * Not all Handlers will support writing values.
+     * Must throw RuntimeException for any failures.
      *
      * @throws RuntimeException
      *
-     * @return mixed
+     * @return void
      */
     public function forget(string $class, string $property, ?string $context = null)
     {

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -63,7 +63,7 @@ class DatabaseHandler extends ArrayHandler
      *
      * @throws RuntimeException For database failures
      *
-     * @return mixed|void
+     * @return void
      */
     public function set(string $class, string $property, $value = null, ?string $context = null)
     {
@@ -103,13 +103,13 @@ class DatabaseHandler extends ArrayHandler
 
         // Update storage
         $this->setStored($class, $property, $value, $context);
-
-        return $result;
     }
 
     /**
      * Deletes the record from persistent storage, if found,
      * and from the local cache.
+     *
+     * @return void
      */
     public function forget(string $class, string $property, ?string $context = null)
     {
@@ -123,13 +123,11 @@ class DatabaseHandler extends ArrayHandler
             ->delete();
 
         if (! $result) {
-            return $result;
+            throw new RuntimeException(db_connect()->error()['message'] ?? 'Error writing to the database.');
         }
 
         // Delete from local storage
         $this->forgetStored($class, $property, $context);
-
-        return $result;
     }
 
     /**
@@ -139,7 +137,7 @@ class DatabaseHandler extends ArrayHandler
      *
      * @throws RuntimeException For database failures
      */
-    private function hydrate(?string $context)
+    private function hydrate(?string $context): void
     {
         // Check for completion
         if (in_array($context, $this->hydrated, true)) {

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -38,9 +38,8 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsNewRows()
     {
-        $results = $this->settings->set('Test.siteName', 'Foo');
+        $this->settings->set('Test.siteName', 'Foo');
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -51,9 +50,8 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsBoolTrue()
     {
-        $results = $this->settings->set('Test.siteName', true);
+        $this->settings->set('Test.siteName', true);
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -66,9 +64,8 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsBoolFalse()
     {
-        $results = $this->settings->set('Test.siteName', false);
+        $this->settings->set('Test.siteName', false);
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -81,9 +78,8 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsNull()
     {
-        $results = $this->settings->set('Test.siteName', null);
+        $this->settings->set('Test.siteName', null);
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -96,10 +92,9 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsArray()
     {
-        $data    = ['foo' => 'bar'];
-        $results = $this->settings->set('Test.siteName', $data);
+        $data = ['foo' => 'bar'];
+        $this->settings->set('Test.siteName', $data);
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -112,10 +107,9 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsObject()
     {
-        $data    = (object) ['foo' => 'bar'];
-        $results = $this->settings->set('Test.siteName', $data);
+        $data = (object) ['foo' => 'bar'];
+        $this->settings->set('Test.siteName', $data);
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -136,9 +130,8 @@ final class DatabaseHandlerTest extends TestCase
             'updated_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $results = $this->settings->set('Test.siteName', 'Bar');
+        $this->settings->set('Test.siteName', 'Bar');
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -148,9 +141,8 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testWorksWithoutConfigClass()
     {
-        $results = $this->settings->set('Nada.siteName', 'Bar');
+        $this->settings->set('Nada.siteName', 'Bar');
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class' => 'Nada',
             'key'   => 'siteName',
@@ -170,9 +162,8 @@ final class DatabaseHandlerTest extends TestCase
             'updated_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $results = $this->settings->forget('Test.siteName');
+        $this->settings->forget('Test.siteName');
 
-        $this->assertTrue($results);
         $this->dontSeeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Test',
             'key'   => 'siteName',
@@ -181,16 +172,18 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testForgetWithNoStoredRecord()
     {
-        $results = $this->settings->forget('Test.siteName');
+        $this->settings->forget('Test.siteName');
 
-        $this->assertTrue($results);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Test',
+            'key'   => 'siteName',
+        ]);
     }
 
     public function testSetWithContext()
     {
-        $results = $this->settings->set('Test.siteName', 'Banana', 'environment:test');
+        $this->settings->set('Test.siteName', 'Banana', 'environment:test');
 
-        $this->assertTrue($results);
         $this->seeInDatabase($this->table, [
             'class'   => 'Tests\Support\Config\Test',
             'key'     => 'siteName',


### PR DESCRIPTION
* Allows for multiple write handlers during `set()` and `forget()`
* Standardizes write method return expectations to `void` with expected exceptions