### PR TITLE
feat: Allow current settings to be completely cleared out.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ phpunit
 composer.lock
 .DS_Store
 .idea/
+.vscode/

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -37,6 +37,12 @@ it effectively resets itself back to the default value in config file, if any.
 service('settings')->forget('App.siteName');
 ```
 
+If you ever need to completely remove all settings from their persistent storage, you can use the `flush()` method. This immediately removes all settings from the database and the in-memory cache.
+
+```php
+service('settings')->flush();
+```
+
 ### Contextual Settings
 
 In addition to the default behavior describe above, `Settings` can be used to define "contextual settings".
@@ -49,7 +55,7 @@ give them a category and identifier, like `environment:production`, `group:super
 
 An example... Say your App config includes the name of a theme to use to enhance your display. By default
 your config file specifies `App.theme = 'default'`. When a user changes their theme, you do not want this to
-change the theme for all visitors to the site, so you need to provide the user as the *context* for the change:
+change the theme for all visitors to the site, so you need to provide the user as the _context_ for the change:
 
 ```php
 $context = 'user:' . user_id();

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -99,3 +99,13 @@ setting()->forget('App.siteName');
 !!! Note
 
     Due to the shorthand nature of the helper function it cannot access contextual settings.
+
+### Commands
+
+From the `spark` command line tool you can clear all settings from the database with the `settings:clear` command.
+
+```bash
+php spark settings:clear
+```
+
+You will be prompted to confirm the action before it is performed.

--- a/src/Commands/ClearSettings.php
+++ b/src/Commands/ClearSettings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Commands;
+namespace CodeIgniter\Settings\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
@@ -13,9 +13,12 @@ class ClearSettings extends BaseCommand
 
     public function run(array $params)
     {
-        if (! CLI::prompt('This will delete all settings from the database. Are you sure you want to continue?', ['y', 'n'], 'required') === 'y') {
+        if (CLI::prompt('This will delete all settings from the database. Are you sure you want to continue?', ['y', 'n'], 'required') === 'y') {
             return;
         }
 
+        service('setting')->flush();
+
+        CLI::write('Settings cleared from the database.', 'green');
     }
 }

--- a/src/Commands/ClearSettings.php
+++ b/src/Commands/ClearSettings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Commands;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\CLI;
+
+class ClearSettings extends BaseCommand
+{
+    protected $group       = 'Housekeeping';
+    protected $name        = 'settings:clear';
+    protected $description = 'Clears all settings from the database.';
+
+    public function run(array $params)
+    {
+        if (! CLI::prompt('This will delete all settings from the database. Are you sure you want to continue?', ['y', 'n'], 'required') === 'y') {
+            return;
+        }
+
+    }
+}

--- a/src/Commands/ClearSettings.php
+++ b/src/Commands/ClearSettings.php
@@ -13,7 +13,7 @@ class ClearSettings extends BaseCommand
 
     public function run(array $params)
     {
-        if (CLI::prompt('This will delete all settings from the database. Are you sure you want to continue?', ['y', 'n'], 'required') === 'y') {
+        if (CLI::prompt('This will delete all settings from the database. Are you sure you want to continue?', ['y', 'n'], 'required') !== 'y') {
             return;
         }
 

--- a/src/Handlers/ArrayHandler.php
+++ b/src/Handlers/ArrayHandler.php
@@ -47,6 +47,12 @@ class ArrayHandler extends BaseHandler
         $this->forgetStored($class, $property, $context);
     }
 
+    public function flush()
+    {
+        $this->general  = [];
+        $this->contexts = [];
+    }
+
     /**
      * Checks whether this value is in storage.
      */

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -51,6 +51,18 @@ abstract class BaseHandler
     }
 
     /**
+     * All handlers MUST support flushing all values.
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function flush()
+    {
+        throw new RuntimeException('Flush method not implemented for current Settings handler.');
+    }
+
+    /**
      * Takes care of converting some item types so they can be safely
      * stored and re-hydrated into the config files.
      *

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -93,7 +93,7 @@ class DatabaseHandler extends ArrayHandler
                     'context'    => $context,
                     'updated_at' => $time,
                 ]);
-        // ...otherwise insert it
+            // ...otherwise insert it
         } else {
             $result = $this->builder
                 ->insert([

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -93,7 +93,7 @@ class DatabaseHandler extends ArrayHandler
                     'context'    => $context,
                     'updated_at' => $time,
                 ]);
-            // ...otherwise insert it
+        // ...otherwise insert it
         } else {
             $result = $this->builder
                 ->insert([
@@ -138,6 +138,19 @@ class DatabaseHandler extends ArrayHandler
 
         // Delete from local storage
         $this->forgetStored($class, $property, $context);
+    }
+
+    /**
+     * Deletes all records from persistent storage, if found,
+     * and from the local cache.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->builder->truncate();
+
+        parent::flush();
     }
 
     /**

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -93,7 +93,7 @@ class DatabaseHandler extends ArrayHandler
                     'context'    => $context,
                     'updated_at' => $time,
                 ]);
-            // ...otherwise insert it
+        // ...otherwise insert it
         } else {
             $result = $this->builder
                 ->insert([

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -102,6 +102,19 @@ class Settings
     }
 
     /**
+     * Removes all settings from the persistent storage,
+     * Useful during testing. Use with caution.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        foreach ($this->getWriteHandlers() as $handler) {
+            $handler->flush();
+        }
+    }
+
+    /**
      * Returns the handler that is set to store values.
      *
      * @return BaseHandler[]

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -221,6 +221,27 @@ final class DatabaseHandlerTest extends TestCase
         ]);
     }
 
+    public function testFlush()
+    {
+        // Default value in the config file
+        $this->assertSame('Settings Test', $this->settings->get('Test.siteName'));
+
+        $this->settings->set('Test.siteName', 'Foo');
+
+        // Should be the last value set
+        $this->assertSame('Foo', $this->settings->get('Test.siteName'));
+
+        $this->settings->flush();
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Test',
+            'key'   => 'siteName',
+        ]);
+
+        // Should be back to the default value
+        $this->assertSame('Settings Test', $this->settings->get('Test.siteName'));
+    }
+
     public function testSetWithContext()
     {
         $this->settings->set('Test.siteName', 'Banana', 'environment:test');


### PR DESCRIPTION
**Description**
Added a new command, `flush()` to the drivers. This allows for easily resetting during testing. 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
