### PR TITLE
fix(app): Fixes a typo in the ClearSettings command that was stopping execution

### DIFF
--- a/src/Commands/ClearSettings.php
+++ b/src/Commands/ClearSettings.php
@@ -17,7 +17,7 @@ class ClearSettings extends BaseCommand
             return;
         }
 
-        service('setting')->flush();
+        service('settings')->flush();
 
         CLI::write('Settings cleared from the database.', 'green');
     }

--- a/src/Config/Settings.php
+++ b/src/Config/Settings.php
@@ -13,7 +13,7 @@ class Settings extends BaseConfig
      * match a public class var here with the
      * settings array containing 'class'.
      *
-     * @var string[]
+     * @var list<string>
      */
     public $handlers = ['database'];
 

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -93,7 +93,7 @@ class DatabaseHandler extends ArrayHandler
                     'context'    => $context,
                     'updated_at' => $time,
                 ]);
-            // ...otherwise insert it
+        // ...otherwise insert it
         } else {
             $result = $this->builder
                 ->insert([

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -27,7 +27,7 @@ class DatabaseHandler extends ArrayHandler
     /**
      * Array of contexts that have been stored.
      *
-     * @var null[]|string[]
+     * @var list<null>|list<string>
      */
     private $hydrated = [];
 
@@ -93,7 +93,7 @@ class DatabaseHandler extends ArrayHandler
                     'context'    => $context,
                     'updated_at' => $time,
                 ]);
-        // ...otherwise insert it
+            // ...otherwise insert it
         } else {
             $result = $this->builder
                 ->insert([

--- a/src/Helpers/setting_helper.php
+++ b/src/Helpers/setting_helper.php
@@ -8,7 +8,7 @@ if (! function_exists('setting')) {
      *
      * @param mixed $value
      *
-     * @return array|bool|float|int|object|Settings|string|void|null
+     * @return         array|bool|float|int|object|Settings|string|void|null
      * @phpstan-return ($key is null ? Settings : ($value is null ? array|bool|float|int|object|string|null : void))
      */
     function setting(?string $key = null, $value = null)

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -17,7 +17,7 @@ class Settings
     /**
      * An array of handlers for getting/setting the values.
      *
-     * @var BaseHandler[]
+     * @var list<BaseHandler>
      */
     private array $handlers = [];
 
@@ -117,7 +117,7 @@ class Settings
     /**
      * Returns the handler that is set to store values.
      *
-     * @return BaseHandler[]
+     * @return list<BaseHandler>
      *
      * @throws RuntimeException
      */
@@ -141,7 +141,7 @@ class Settings
     /**
      * Analyzes the given key and breaks it into the class.field parts.
      *
-     * @return string[]
+     * @return list<string>
      *
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
When running `spark settings:clear` it was throwing an error because of a typo on the service it was calling. 

```bash
Call to a member function flush() on null

at VENDORPATH/codeigniter4/settings/src/Commands/ClearSettings.php:20
```

This adds the required `s` to make it `settings` and allow the command to run.  