### PR TITLE
chore: fix PHPUnit version to ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "codeigniter4/devkit": "^1.1.2",
         "codeigniter4/framework": "^4.2.3",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "1.0.5"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
**Description**
This project is still using PHPUnit 9.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
