### PR TITLE
chore: update dependencies to support PHP 8.1 - 8.4

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   deptrac:
-    uses: codeigniter4/.github/.github/workflows/deptrac.yml@main
+    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI46

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   phpcpd:
-    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI46
     with:
       dirs: "src/ tests/"

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   phpcsfixer:
-    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI46

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpstan:
-    uses: codeigniter4/.github/.github/workflows/phpstan.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI46

--- a/.github/workflows/phpunit-lowest.yml
+++ b/.github/workflows/phpunit-lowest.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpunit:
-    uses: codeigniter4/.github/.github/workflows/phpunit-lowest.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpunit-lowest.yml@CI46

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpunit:
-    uses: codeigniter4/.github/.github/workflows/phpunit.yml@main
+    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI46

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   psalm:
-    uses: codeigniter4/.github/.github/workflows/psalm.yml@main
+    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI46

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/rector.yml@main
+    uses: codeigniter4/.github/.github/workflows/rector.yml@CI46

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -18,4 +18,4 @@ on:
 
 jobs:
   unused:
-    uses: codeigniter4/.github/.github/workflows/unused.yml@main
+    uses: codeigniter4/.github/.github/workflows/unused.yml@CI46

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ config classes for CodeIgniter 4 framework.
 [![](https://github.com/codeigniter4/settings/workflows/Deptrac/badge.svg)](https://github.com/codeigniter4/settings/actions/workflows/inspect.yml)
 [![Coverage Status](https://coveralls.io/repos/github/codeigniter4/settings/badge.svg?branch=develop)](https://coveralls.io/github/codeigniter4/settings?branch=develop)
 
-![PHP](https://img.shields.io/badge/PHP-%5E7.4-blue)
+![PHP](https://img.shields.io/badge/PHP-%5E8.1-blue)
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.2.3-blue)
 ![License](https://img.shields.io/badge/License-MIT-blue)
 

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,11 @@
     ],
     "homepage": "https://github.com/codeigniter4/settings",
     "require": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "codeigniter/coding-standard": "1.7.*",
-        "codeigniter4/devkit": "^1.1.2",
-        "codeigniter4/framework": "^4.2.3",
-        "phpunit/phpunit": "^9.6",
-        "rector/rector": "1.2.8"
+        "codeigniter4/devkit": "^1.3",
+        "codeigniter4/framework": "^4.2.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ service('settings')->forget('App.siteName');
 
 ### Requirements
 
-![PHP](https://img.shields.io/badge/PHP-%5E7.4-red)
+![PHP](https://img.shields.io/badge/PHP-%5E8.1-red)
 ![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.2.3-red)
 
 ### Acknowledgements

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Offset string does not exist on list\<CodeIgniter\\Settings\\Handlers\\BaseHandler\>\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: src/Settings.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''CodeIgniter\\\\Settings\\\\Settings'' and CodeIgniter\\Settings\\Settings will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: tests/HelperTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,22 +1,21 @@
+includes:
+    - phpstan-baseline.neon
 parameters:
-	tmpDir: build/phpstan
-	level: 5
-	paths:
-		- src/
-		- tests/
-	bootstrapFiles:
-		- vendor/codeigniter4/framework/system/Test/bootstrap.php
-	excludePaths:
-		- src/Config/Routes.php
-		- src/Views/*
-	ignoreErrors:
-	universalObjectCratesClasses:
-		- CodeIgniter\Entity
-		- CodeIgniter\Entity\Entity
-		- Faker\Generator
-	scanDirectories:
-		- vendor/codeigniter4/framework/system/Helpers
-	dynamicConstantNames:
-		- APP_NAMESPACE
-		- CI_DEBUG
-		- ENVIRONMENT
+    tmpDir: build/phpstan
+    level: 5
+    paths:
+        - src/
+        - tests/
+    bootstrapFiles:
+        - vendor/codeigniter4/framework/system/Test/bootstrap.php
+    excludePaths:
+    universalObjectCratesClasses:
+        - CodeIgniter\Entity
+        - CodeIgniter\Entity\Entity
+        - Faker\Generator
+    scanDirectories:
+        - vendor/codeigniter4/framework/system/Helpers
+    dynamicConstantNames:
+        - APP_NAMESPACE
+        - CI_DEBUG
+        - ENVIRONMENT

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,102 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-		bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
-		backupGlobals="false"
-		beStrictAboutCoversAnnotation="true"
-		beStrictAboutOutputDuringTests="true"
-		beStrictAboutTodoAnnotatedTests="true"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		executionOrder="random"
-		failOnRisky="true"
-		failOnWarning="true"
-		stopOnError="false"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
+         backupGlobals="false"
+         beStrictAboutOutputDuringTests="true"
+         colors="true"
+         executionOrder="random"
+         failOnRisky="true"
+         failOnWarning="true"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         cacheDirectory="build/.phpunit.cache"
+         beStrictAboutCoverageMetadata="true">
 
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./src/</directory>
-		</include>
-		<exclude>
-			<directory suffix=".php">./src/Config</directory>
-			<directory suffix=".php">./src/Views</directory>
-		</exclude>
-		<report>
-			<clover outputFile="build/phpunit/clover.xml"/>
-			<html outputDirectory="build/phpunit/html"/>
-			<php outputFile="build/phpunit/coverage.serialized"/>
-			<text outputFile="php://stdout" showUncoveredFiles="false"/>
-			<xml outputDirectory="build/phpunit/xml-coverage"/>
-		</report>
-	</coverage>
+    <coverage includeUncoveredFiles="true">
+        <report>
+            <clover outputFile="build/phpunit/clover.xml"/>
+            <html outputDirectory="build/phpunit/html"/>
+            <php outputFile="build/phpunit/coverage.serialized"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <xml outputDirectory="build/phpunit/xml-coverage"/>
+        </report>
+    </coverage>
 
-	<testsuites>
-		<testsuite name="main">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="main">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
 
-	<extensions>
-		<extension class="Nexus\PHPUnit\Extension\Tachycardia">
-			<arguments>
-				<array>
-					<element key="timeLimit">
-						<double>0.50</double>
-					</element>
-					<element key="reportable">
-						<integer>30</integer>
-					</element>
-					<element key="precision">
-						<integer>2</integer>
-					</element>
-					<element key="collectBare">
-						<boolean>true</boolean>
-					</element>
-					<element key="tabulate">
-						<boolean>true</boolean>
-					</element>
-				</array>
-			</arguments>
-		</extension>
-	</extensions>
+    <extensions>
+        <bootstrap class="Nexus\PHPUnit\Tachycardia\TachycardiaExtension">
+            <parameter name="time-limit" value="0.50"/>
+            <parameter name="report-count" value="30"/>
+            <parameter name="format" value="table"/>
+        </bootstrap>
+    </extensions>
 
-	<logging>
-		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
-		<testdoxText outputFile="build/phpunit/testdox.txt"/>
-		<junit outputFile="build/phpunit/junit.xml"/>
-	</logging>
+    <logging>
+        <testdoxHtml outputFile="build/phpunit/testdox.html"/>
+        <testdoxText outputFile="build/phpunit/testdox.txt"/>
+        <junit outputFile="build/phpunit/junit.xml"/>
+    </logging>
 
-	<php>
-		<env name="XDEBUG_MODE" value="coverage"/>
-		<server name="app.baseURL" value="https://example.com/"/>
+    <php>
+        <env name="XDEBUG_MODE" value="coverage"/>
+        <server name="app.baseURL" value="https://example.com/"/>
 
-		<!-- Directory containing phpunit.xml -->
-		<const name="HOMEPATH" value="./"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
 
-		<!-- Directory containing the Paths config file -->
-		<const name="CONFIGPATH" value="./vendor/codeigniter4/framework/app/Config/"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="vendor/codeigniter4/framework/app/Config/"/>
 
-		<!-- Directory containing the front controller (index.php) -->
-		<const name="PUBLICPATH" value="./vendor/codeigniter4/framework/public/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./public/"/>
 
-		<!-- https://getcomposer.org/xdebug -->
-		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
+        <!-- https://getcomposer.org/xdebug -->
+        <env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
 
-		<!-- Database configuration -->
-		<env name="database.tests.strictOn" value="true"/>
-		<!-- Uncomment to use alternate testing database configuration
-		<env name="database.tests.hostname" value="localhost"/>
-		<env name="database.tests.database" value="tests"/>
-		<env name="database.tests.username" value="tests_user"/>
-		<env name="database.tests.password" value=""/>
-		<env name="database.tests.DBDriver" value="MySQLi"/>
-		<env name="database.tests.DBPrefix" value="tests_"/>
-		-->
-	</php>
+        <!-- Database configuration -->
+        <env name="database.tests.strictOn" value="true"/>
+        <!-- Uncomment to use alternate testing database configuration
+        <env name="database.tests.hostname" value="localhost"/>
+        <env name="database.tests.database" value="tests"/>
+        <env name="database.tests.username" value="tests_user"/>
+        <env name="database.tests.password" value=""/>
+        <env name="database.tests.DBDriver" value="MySQLi"/>
+        <env name="database.tests.DBPrefix" value="tests_"/>
+        -->
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./src/Config</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,6 +11,7 @@
     errorBaseline="psalm-baseline.xml"
     findUnusedBaselineEntry="false"
     findUnusedCode="false"
+    ensureOverrideAttribute="false"
 >
     <projectFiles>
         <directory name="src/" />

--- a/rector.php
+++ b/rector.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Settings.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
 use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
 use Rector\CodeQuality\Rector\Expression\InlineIfToExplicitIfRector;
 use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
@@ -26,7 +37,6 @@ use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -89,9 +99,4 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(FuncGetArgsToVariadicParamRector::class);
     $rectorConfig->rule(MakeInheritedMethodVisibilitySameAsParentRector::class);
     $rectorConfig->rule(SimplifyEmptyArrayCheckRector::class);
-    $rectorConfig
-        ->ruleWithConfiguration(TypedPropertyFromAssignsRector::class, [
-            // Set to false if you use in libraries, or it does create breaking changes.
-            TypedPropertyFromAssignsRector::INLINE_PUBLIC => false,
-        ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -37,6 +37,7 @@ use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -99,4 +100,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(FuncGetArgsToVariadicParamRector::class);
     $rectorConfig->rule(MakeInheritedMethodVisibilitySameAsParentRector::class);
     $rectorConfig->rule(SimplifyEmptyArrayCheckRector::class);
+    $rectorConfig->rule(TypedPropertyFromAssignsRector::class);
 };

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -156,7 +156,7 @@ abstract class BaseHandler
                     if ('"' !== substr($data, -2, 1)) {
                         return false;
                     }
-                } elseif (false === strpos($data, '"')) {
+                } elseif (! str_contains($data, '"')) {
                     return false;
                 }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -170,7 +170,7 @@ class Settings
         // Use a fully qualified class name if the
         // config file was found.
         if ($config !== null) {
-            $class = get_class($config);
+            $class = $config::class;
         }
 
         return [$class, $property, $config];

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -46,10 +46,10 @@ final class DatabaseHandlerTest extends TestCase
 
     public function testSetInsertsNewRows()
     {
-        $this->settings->set('Test.siteName', 'Foo');
+        $this->settings->set('Example.siteName', 'Foo');
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => 'Foo',
             'type'  => 'string',
@@ -67,7 +67,7 @@ final class DatabaseHandlerTest extends TestCase
 
         $this->settings = new Settings($config);
 
-        $this->settings->set('Test.siteName', true);
+        $this->settings->set('Example.siteName', true);
     }
 
     public function testSetDefaultGroup()
@@ -77,104 +77,104 @@ final class DatabaseHandlerTest extends TestCase
         $config->handlers          = ['database'];
         $config->database['group'] = 'default';
 
-        $this->settings->set('Test.siteName', true);
+        $this->settings->set('Example.siteName', true);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => '1',
             'type'  => 'boolean',
         ]);
 
-        $this->assertTrue($this->settings->get('Test.siteName'));
+        $this->assertTrue($this->settings->get('Example.siteName'));
     }
 
     public function testSetInsertsBoolTrue()
     {
-        $this->settings->set('Test.siteName', true);
+        $this->settings->set('Example.siteName', true);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => '1',
             'type'  => 'boolean',
         ]);
 
-        $this->assertTrue($this->settings->get('Test.siteName'));
+        $this->assertTrue($this->settings->get('Example.siteName'));
     }
 
     public function testSetInsertsBoolFalse()
     {
-        $this->settings->set('Test.siteName', false);
+        $this->settings->set('Example.siteName', false);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => '0',
             'type'  => 'boolean',
         ]);
 
-        $this->assertFalse($this->settings->get('Test.siteName'));
+        $this->assertFalse($this->settings->get('Example.siteName'));
     }
 
     public function testSetInsertsNull()
     {
-        $this->settings->set('Test.siteName', null);
+        $this->settings->set('Example.siteName', null);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => null,
             'type'  => 'NULL',
         ]);
 
-        $this->assertNull($this->settings->get('Test.siteName'));
+        $this->assertNull($this->settings->get('Example.siteName'));
     }
 
     public function testSetInsertsArray()
     {
         $data = ['foo' => 'bar'];
-        $this->settings->set('Test.siteName', $data);
+        $this->settings->set('Example.siteName', $data);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => serialize($data),
             'type'  => 'array',
         ]);
 
-        $this->assertSame($data, $this->settings->get('Test.siteName'));
+        $this->assertSame($data, $this->settings->get('Example.siteName'));
     }
 
     public function testSetInsertsObject()
     {
         $data = (object) ['foo' => 'bar'];
-        $this->settings->set('Test.siteName', $data);
+        $this->settings->set('Example.siteName', $data);
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => serialize($data),
             'type'  => 'object',
         ]);
 
-        $this->assertSame((array) $data, (array) $this->settings->get('Test.siteName'));
+        $this->assertSame((array) $data, (array) $this->settings->get('Example.siteName'));
     }
 
     public function testSetUpdatesExistingRows()
     {
         $this->hasInDatabase($this->table, [
-            'class'      => 'Tests\Support\Config\Test',
+            'class'      => 'Tests\Support\Config\Example',
             'key'        => 'siteName',
             'value'      => 'foo',
             'created_at' => Time::now()->toDateTimeString(),
             'updated_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $this->settings->set('Test.siteName', 'Bar');
+        $this->settings->set('Example.siteName', 'Bar');
 
         $this->seeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
             'value' => 'Bar',
         ]);
@@ -196,27 +196,27 @@ final class DatabaseHandlerTest extends TestCase
     public function testForgetSuccess()
     {
         $this->hasInDatabase($this->table, [
-            'class'      => 'Tests\Support\Config\Test',
+            'class'      => 'Tests\Support\Config\Example',
             'key'        => 'siteName',
             'value'      => 'foo',
             'created_at' => Time::now()->toDateTimeString(),
             'updated_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $this->settings->forget('Test.siteName');
+        $this->settings->forget('Example.siteName');
 
         $this->dontSeeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
         ]);
     }
 
     public function testForgetWithNoStoredRecord()
     {
-        $this->settings->forget('Test.siteName');
+        $this->settings->forget('Example.siteName');
 
         $this->dontSeeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
         ]);
     }
@@ -224,30 +224,30 @@ final class DatabaseHandlerTest extends TestCase
     public function testFlush()
     {
         // Default value in the config file
-        $this->assertSame('Settings Test', $this->settings->get('Test.siteName'));
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
 
-        $this->settings->set('Test.siteName', 'Foo');
+        $this->settings->set('Example.siteName', 'Foo');
 
         // Should be the last value set
-        $this->assertSame('Foo', $this->settings->get('Test.siteName'));
+        $this->assertSame('Foo', $this->settings->get('Example.siteName'));
 
         $this->settings->flush();
 
         $this->dontSeeInDatabase($this->table, [
-            'class' => 'Tests\Support\Config\Test',
+            'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteName',
         ]);
 
         // Should be back to the default value
-        $this->assertSame('Settings Test', $this->settings->get('Test.siteName'));
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
     }
 
     public function testSetWithContext()
     {
-        $this->settings->set('Test.siteName', 'Banana', 'environment:test');
+        $this->settings->set('Example.siteName', 'Banana', 'environment:test');
 
         $this->seeInDatabase($this->table, [
-            'class'   => 'Tests\Support\Config\Test',
+            'class'   => 'Tests\Support\Config\Example',
             'key'     => 'siteName',
             'value'   => 'Banana',
             'type'    => 'string',
@@ -260,13 +260,13 @@ final class DatabaseHandlerTest extends TestCase
      */
     public function testSetUpdatesContextOnly()
     {
-        $this->settings->set('Test.siteName', 'Humpty');
-        $this->settings->set('Test.siteName', 'Jack', 'context:male');
-        $this->settings->set('Test.siteName', 'Jill', 'context:female');
-        $this->settings->set('Test.siteName', 'Jane', 'context:female');
+        $this->settings->set('Example.siteName', 'Humpty');
+        $this->settings->set('Example.siteName', 'Jack', 'context:male');
+        $this->settings->set('Example.siteName', 'Jill', 'context:female');
+        $this->settings->set('Example.siteName', 'Jane', 'context:female');
 
         $this->seeInDatabase($this->table, [
-            'class'   => 'Tests\Support\Config\Test',
+            'class'   => 'Tests\Support\Config\Example',
             'key'     => 'siteName',
             'value'   => 'Jane',
             'type'    => 'string',
@@ -274,14 +274,14 @@ final class DatabaseHandlerTest extends TestCase
         ]);
 
         $this->seeInDatabase($this->table, [
-            'class'   => 'Tests\Support\Config\Test',
+            'class'   => 'Tests\Support\Config\Example',
             'key'     => 'siteName',
             'value'   => 'Humpty',
             'type'    => 'string',
             'context' => null,
         ]);
         $this->seeInDatabase($this->table, [
-            'class'   => 'Tests\Support\Config\Test',
+            'class'   => 'Tests\Support\Config\Example',
             'key'     => 'siteName',
             'value'   => 'Jack',
             'type'    => 'string',

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -37,37 +37,37 @@ final class SettingsTest extends TestCase
 
     public function testSettingsGetsFromConfig()
     {
-        $this->assertSame(config('Test')->siteName, $this->settings->get('Test.siteName'));
+        $this->assertSame(config('Example')->siteName, $this->settings->get('Example.siteName'));
     }
 
     public function testSettingsNotFound()
     {
-        $this->assertSame(config('Test')->siteName, $this->settings->get('Test.siteName'));
+        $this->assertSame(config('Example')->siteName, $this->settings->get('Example.siteName'));
     }
 
     public function testGetWithContext()
     {
-        $this->settings->set('Test.siteName', 'NoContext');
-        $this->settings->set('Test.siteName', 'YesContext', 'testing:true');
+        $this->settings->set('Example.siteName', 'NoContext');
+        $this->settings->set('Example.siteName', 'YesContext', 'testing:true');
 
-        $this->assertSame('NoContext', $this->settings->get('Test.siteName'));
-        $this->assertSame('YesContext', $this->settings->get('Test.siteName', 'testing:true'));
+        $this->assertSame('NoContext', $this->settings->get('Example.siteName'));
+        $this->assertSame('YesContext', $this->settings->get('Example.siteName', 'testing:true'));
     }
 
     public function testGetWithoutContextUsesGlobal()
     {
-        $this->settings->set('Test.siteName', 'NoContext');
+        $this->settings->set('Example.siteName', 'NoContext');
 
-        $this->assertSame('NoContext', $this->settings->get('Test.siteName', 'testing:true'));
+        $this->assertSame('NoContext', $this->settings->get('Example.siteName', 'testing:true'));
     }
 
     public function testForgetWithContext()
     {
-        $this->settings->set('Test.siteName', 'Bar');
-        $this->settings->set('Test.siteName', 'Amnesia', 'category:disease');
+        $this->settings->set('Example.siteName', 'Bar');
+        $this->settings->set('Example.siteName', 'Amnesia', 'category:disease');
 
-        $this->settings->forget('Test.siteName', 'category:disease');
+        $this->settings->forget('Example.siteName', 'category:disease');
 
-        $this->assertSame('Bar', $this->settings->get('Test.siteName', 'category:disease'));
+        $this->assertSame('Bar', $this->settings->get('Example.siteName', 'category:disease'));
     }
 }

--- a/tests/_support/Config/Example.php
+++ b/tests/_support/Config/Example.php
@@ -7,7 +7,7 @@ use CodeIgniter\Config\BaseConfig;
 /**
  * @internal
  */
-final class Test extends BaseConfig
+final class Example extends BaseConfig
 {
     public $siteName = 'Settings Test';
 }

--- a/tests/_support/TestCase.php
+++ b/tests/_support/TestCase.php
@@ -6,12 +6,9 @@ use CodeIgniter\Settings\Handlers\ArrayHandler;
 use CodeIgniter\Settings\Settings;
 use CodeIgniter\Test\CIUnitTestCase;
 use Config\Services;
-use Nexus\PHPUnit\Extension\Expeditable;
 
 abstract class TestCase extends CIUnitTestCase
 {
-    use Expeditable;
-
     /**
      * @var Settings
      */


### PR DESCRIPTION
**Description**
This PR updates the dependencies and sets the required PHP version to 8.1. We now run tests on all currently supported versions of PHP, the same as the main project.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
