### PR TITLE
Introducing `take` Method

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -43,6 +43,13 @@ If you ever need to completely remove all settings from their persistent storage
 service('settings')->flush();
 ```
 
+Also, you can use the `pull()` method to retrieve a setting and then remove it from the persistent storage in one go. This is useful when you want to retrieve a value and ensure it is no longer available for future use.
+
+```php
+// The same as config('App')->siteName;
+$siteName = service('settings')->pull('App.siteName');
+```
+
 ### Contextual Settings
 
 In addition to the default behavior describe above, `Settings` can be used to define "contextual settings".

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -46,7 +46,6 @@ service('settings')->flush();
 Also, you can use the `pull()` method to retrieve a setting and then remove it from the persistent storage in one go. This is useful when you want to retrieve a value and ensure it is no longer available for future use.
 
 ```php
-// The same as config('App')->siteName;
 $siteName = service('settings')->pull('App.siteName');
 ```
 

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -43,10 +43,10 @@ If you ever need to completely remove all settings from their persistent storage
 service('settings')->flush();
 ```
 
-Also, you can use the `pull()` method to retrieve a setting and then remove it from the persistent storage in one go. This is useful when you want to retrieve a value and ensure it is no longer available for future use.
+Also, you can use the `take()` method to retrieve a setting and then remove it from the persistent storage in one go. This is useful when you want to retrieve a value and ensure it is no longer available for future use.
 
 ```php
-$siteName = service('settings')->pull('App.siteName');
+$siteName = service('settings')->take('App.siteName');
 ```
 
 ### Contextual Settings

--- a/src/Handlers/ArrayHandler.php
+++ b/src/Handlers/ArrayHandler.php
@@ -47,6 +47,15 @@ class ArrayHandler extends BaseHandler
         $this->forgetStored($class, $property, $context);
     }
 
+    public function pull(string $class, string $property, ?string $context = null): mixed
+    {
+        $value = $this->getStored($class, $property, $context);
+
+        $this->forget($class, $property, $context);
+
+        return $value;
+    }
+
     public function flush()
     {
         $this->general  = [];

--- a/src/Handlers/ArrayHandler.php
+++ b/src/Handlers/ArrayHandler.php
@@ -47,7 +47,7 @@ class ArrayHandler extends BaseHandler
         $this->forgetStored($class, $property, $context);
     }
 
-    public function pull(string $class, string $property, ?string $context = null): mixed
+    public function take(string $class, string $property, ?string $context = null): mixed
     {
         $value = $this->get($class, $property, $context);
 

--- a/src/Handlers/ArrayHandler.php
+++ b/src/Handlers/ArrayHandler.php
@@ -49,7 +49,7 @@ class ArrayHandler extends BaseHandler
 
     public function pull(string $class, string $property, ?string $context = null): mixed
     {
-        $value = $this->getStored($class, $property, $context);
+        $value = $this->get($class, $property, $context);
 
         $this->forget($class, $property, $context);
 

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -51,6 +51,21 @@ abstract class BaseHandler
     }
 
     /**
+     * If the Handler supports pulling values, it
+     * MUST override this method to provide that functionality.
+     * Not all Handlers will support writing values.
+     * Must throw RuntimeException for any failures.
+     *
+     * @return mixed
+     *
+     * @throws RuntimeException
+     */
+    public function pull(string $class, string $property, ?string $context = null)
+    {
+        throw new RuntimeException('Pull method not implemented for current Settings handler.');
+    }
+
+    /**
      * All handlers MUST support flushing all values.
      *
      * @return void

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -60,7 +60,7 @@ abstract class BaseHandler
      *
      * @throws RuntimeException
      */
-    public function pull(string $class, string $property, ?string $context = null)
+    public function take(string $class, string $property, ?string $context = null)
     {
         throw new RuntimeException('Pull method not implemented for current Settings handler.');
     }

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -146,7 +146,7 @@ class DatabaseHandler extends ArrayHandler
      *
      * @return mixed|null
      */
-    public function pull(string $class, string $property, ?string $context = null): mixed
+    public function take(string $class, string $property, ?string $context = null): mixed
     {
         $value = $this->get($class, $property, $context);
 

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -148,7 +148,7 @@ class DatabaseHandler extends ArrayHandler
      */
     public function pull(string $class, string $property, ?string $context = null): mixed
     {
-        $value = $this->getStored($class, $property, $context);
+        $value = $this->get($class, $property, $context);
 
         $this->forget($class, $property, $context);
 

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -141,6 +141,21 @@ class DatabaseHandler extends ArrayHandler
     }
 
     /**
+     * Retrieves a value from persistent storage
+     * and deletes it from the local cache.
+     *
+     * @return mixed|null
+     */
+    public function pull(string $class, string $property, ?string $context = null): mixed
+    {
+        $value = $this->getStored($class, $property, $context);
+
+        $this->forget($class, $property, $context);
+
+        return $value;
+    }
+
+    /**
      * Deletes all records from persistent storage, if found,
      * and from the local cache.
      *

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -102,6 +102,20 @@ class Settings
     }
 
     /**
+     * Retrieves a value from the persistent storage and removes it.
+     *
+     * @return void
+     */
+    public function pull(string $key, ?string $context = null)
+    {
+        [$class, $property] = $this->prepareClassAndProperty($key);
+
+        foreach ($this->getWriteHandlers() as $handler) {
+            return $handler->pull($class, $property, $context);
+        }
+    }
+
+    /**
      * Removes all settings from the persistent storage,
      * Useful during testing. Use with caution.
      *

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -104,7 +104,7 @@ class Settings
     /**
      * Retrieves a value from the persistent storage and removes it.
      *
-     * @return void
+     * @return mixed
      */
     public function pull(string $key, ?string $context = null)
     {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -106,12 +106,12 @@ class Settings
      *
      * @return mixed
      */
-    public function pull(string $key, ?string $context = null)
+    public function take(string $key, ?string $context = null)
     {
         [$class, $property] = $this->prepareClassAndProperty($key);
 
         foreach ($this->getWriteHandlers() as $handler) {
-            return $handler->pull($class, $property, $context);
+            return $handler->take($class, $property, $context);
         }
     }
 

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -221,7 +221,7 @@ final class DatabaseHandlerTest extends TestCase
             'updated_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $value = $this->settings->pull('Example.siteName');
+        $value = $this->settings->take('Example.siteName');
 
         $this->dontSeeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Example',

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -211,6 +211,26 @@ final class DatabaseHandlerTest extends TestCase
         ]);
     }
 
+    public function testPullSuccess()
+    {
+        $this->hasInDatabase($this->table, [
+            'class'      => 'Tests\Support\Config\Example',
+            'key'        => 'siteName',
+            'value'      => 'foo',
+            'created_at' => Time::now()->toDateTimeString(),
+            'updated_at' => Time::now()->toDateTimeString(),
+        ]);
+
+        $value = $this->settings->pull('Example.siteName');
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+
+        $this->assertSame('foo', $value);
+    }
+
     public function testForgetWithNoStoredRecord()
     {
         $this->settings->forget('Example.siteName');

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -70,4 +70,24 @@ final class SettingsTest extends TestCase
 
         $this->assertSame('Bar', $this->settings->get('Example.siteName', 'category:disease'));
     }
+
+    public function testPullWithContext()
+    {
+        $this->settings->set('Example.siteName', 'Amnesia', 'category:disease');
+
+        $value = $this->settings->pull('Example.siteName', 'category:disease');
+
+        $this->assertSame('Amnesia', $value);
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName', 'category:disease'));
+    }
+
+    public function testPullWithoutContext()
+    {
+        $this->settings->set('Example.siteName', 'NoContext');
+
+        $value = $this->settings->pull('Example.siteName');
+
+        $this->assertSame('NoContext', $value);
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
+    }
 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -75,7 +75,7 @@ final class SettingsTest extends TestCase
     {
         $this->settings->set('Example.siteName', 'Amnesia', 'category:disease');
 
-        $value = $this->settings->pull('Example.siteName', 'category:disease');
+        $value = $this->settings->take('Example.siteName', 'category:disease');
 
         $this->assertSame('Amnesia', $value);
         $this->assertSame('Settings Test', $this->settings->get('Example.siteName', 'category:disease'));
@@ -85,7 +85,7 @@ final class SettingsTest extends TestCase
     {
         $this->settings->set('Example.siteName', 'NoContext');
 
-        $value = $this->settings->pull('Example.siteName');
+        $value = $this->settings->take('Example.siteName');
 
         $this->assertSame('NoContext', $value);
         $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

Hey, folks! After a long period, I'd like to get back to contributing to CodeIgniter 'cause this was my first framework during my career. This PR aims to introduce the `take` method, which can be used to perform two operations in a single interaction: `get` + `flush`, improving the dev experience in favor to avoid the need to manually perform these two operations individually

**Demonstration**

```php
$siteName = service('settings')->take('App.siteName');
```

**Checklist:**
- [ ] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
