### PR TITLE
chore: make docs copyright year automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.lock
 .DS_Store
 .idea/
 .vscode/
+docs/assets/__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2021 Lonnie Ezell
-Copyright (c) 2021-2026 CodeIgniter Foundation
+Copyright (c) 2021-present CodeIgniter Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2021 Lonnie Ezell
+Copyright (c) 2021-2026 CodeIgniter Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/assets/hooks.py
+++ b/docs/assets/hooks.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-
 def on_config(config, **kwargs):
     config.copyright = config.copyright.format(year=datetime.now().year)
     return config

--- a/docs/assets/hooks.py
+++ b/docs/assets/hooks.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+def on_config(config, **kwargs):
+    config.copyright = config.copyright.format(year=datetime.now().year)
+    return config

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ service('settings')->forget('App.siteName');
 ### Requirements
 
 ![PHP](https://img.shields.io/badge/PHP-%5E8.2-red)
-![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.2.3-red)
+![CodeIgniter](https://img.shields.io/badge/CodeIgniter-%5E4.3-red)
 
 ### Acknowledgements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ extra:
 site_url: https://settings.codeigniter.com/
 repo_url: https://github.com/codeigniter4/settings
 edit_uri: edit/develop/docs/
-copyright: Copyright &copy; {year} CodeIgniter Foundation.
+copyright: Copyright &copy; 2021-{year} CodeIgniter Foundation.
 
 hooks:
   - docs/assets/hooks.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,10 @@ extra:
 site_url: https://settings.codeigniter.com/
 repo_url: https://github.com/codeigniter4/settings
 edit_uri: edit/develop/docs/
-copyright: Copyright &copy; 2025 CodeIgniter Foundation.
+copyright: Copyright &copy; {year} CodeIgniter Foundation.
+
+hooks:
+  - docs/assets/hooks.py
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
**Description**
This PR automates the copyright year in the documentation so it always reflects the current year during build.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
