### PR TITLE
feat: add batch setting operations

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -30,11 +30,30 @@ when retrieved.
 service('settings')->set('App.siteName', 'My Great Site');
 ```
 
+You can save multiple values with `setMany()`. This behaves like calling `set()` for each key/value pair,
+but allows supported handlers to persist the changes more efficiently.
+
+```php
+service('settings')->setMany([
+    'App.siteName'  => 'My Great Site',
+    'App.siteEmail' => 'support@example.com',
+]);
+```
+
 You can delete a value from the persistent storage with the `forget()` method. Since it is removed from the storage,
 it effectively resets itself back to the default value in config file, if any.
 
 ```php
 service('settings')->forget('App.siteName');
+```
+
+You can delete multiple values with `forgetMany()`.
+
+```php
+service('settings')->forgetMany([
+    'App.siteName',
+    'App.siteEmail',
+]);
 ```
 
 If you ever need to completely remove all settings from their persistent storage, you can use the `flush()` method. This immediately removes all settings from the database and the in-memory cache.
@@ -60,6 +79,16 @@ change the theme for all visitors to the site, so you need to provide the user a
 ```php
 $context = 'user:' . user_id();
 service('settings')->set('App.theme', 'dark', $context);
+```
+
+The same context can be applied to a batch of values:
+
+```php
+$context = 'user:' . user_id();
+service('settings')->setMany([
+    'App.theme' => 'dark',
+    'App.locale' => 'en',
+], $context);
 ```
 
 Now when your filter is determining which theme to apply it can check for the current user as the context:
@@ -91,9 +120,17 @@ setting('App.siteName', 'My Great Site');
 // Using the service through the helper
 $name = setting()->get('App.siteName');
 setting()->set('App.siteName', 'My Great Site');
+setting()->setMany([
+    'App.siteName'  => 'My Great Site',
+    'App.siteEmail' => 'support@example.com',
+]);
 
 // Forgetting a value
 setting()->forget('App.siteName');
+setting()->forgetMany([
+    'App.siteName',
+    'App.siteEmail',
+]);
 ```
 
 !!! Note

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,8 +32,10 @@ Handlers like `database` and `file` support deferred writes. When `deferWrites` 
 are batched and persisted efficiently at the end of the request during the `post_system` event. This minimizes the number of
 database queries or file I/O operations, improving performance for write-heavy operations.
 
-This is separate from the explicit `setMany()` and `forgetMany()` APIs. Batch APIs allow callers to group multiple settings in
-one method call, while deferred writes decide whether writes are persisted immediately or at the end of the request.
+!!! note
+    This is separate from the explicit `setMany()` and `forgetMany()` APIs. Batch APIs allow callers to group multiple settings
+    in one method call, while deferred writes decide whether writes are persisted immediately or at the end of the request.
+    The two features are independent and can be combined.
 
 ### Multiple handlers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,9 @@ Handlers like `database` and `file` support deferred writes. When `deferWrites` 
 are batched and persisted efficiently at the end of the request during the `post_system` event. This minimizes the number of
 database queries or file I/O operations, improving performance for write-heavy operations.
 
+This is separate from the explicit `setMany()` and `forgetMany()` APIs. Batch APIs allow callers to group multiple settings in
+one method call, while deferred writes decide whether writes are persisted immediately or at the end of the request.
+
 ### Multiple handlers
 
 Example:
@@ -94,6 +97,16 @@ $settings->set('Example.prop3', 'value3');
 
 The deferred approach is especially beneficial when updating existing records or performing many operations in a single request.
 
+For explicit batches, use `setMany()` or `forgetMany()`:
+
+```php
+$settings->setMany([
+    'Example.prop1' => 'value1',
+    'Example.prop2' => 'value2',
+    'Example.prop3' => 'value3',
+]);
+```
+
 ---
 
 ## FileHandler
@@ -135,6 +148,16 @@ $settings->set('Example.prop3', 'value3');
 ```
 
 The deferred approach is especially beneficial when updating multiple properties in the same class.
+
+For explicit batches, use `setMany()` or `forgetMany()`:
+
+```php
+$settings->setMany([
+    'Example.prop1' => 'value1',
+    'Example.prop2' => 'value2',
+    'Example.prop3' => 'value3',
+]);
+```
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -5,8 +5,8 @@ The following are known limitations of the library:
 1. **Immediate writes (`deferWrites => false`)**: Each setting is written to storage immediately when you call `set()` or `forget()`.
    The first operation hydrates all settings for that context (1 SELECT query), then each subsequent write performs a separate
    INSERT or UPDATE. While `DatabaseHandler` and `FileHandler` use an in-memory cache to maintain fast reads, individual write
-   operations may result in multiple database queries or file writes per request. Use `setMany()` or `forgetMany()` when you
-   want to explicitly persist multiple settings in one batch operation.
+   operations may result in multiple database queries or file writes per request. When multiple changes are known ahead of time,
+   use `setMany()` or `forgetMany()` to group them explicitly and allow supported handlers to persist them more efficiently.
 
 2. **Deferred writes (`deferWrites => true`)**: All settings are batched and written to storage at the end of the request
    (during the `post_system` event). This minimizes the number of database queries and file writes, improving performance.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -5,7 +5,8 @@ The following are known limitations of the library:
 1. **Immediate writes (`deferWrites => false`)**: Each setting is written to storage immediately when you call `set()` or `forget()`.
    The first operation hydrates all settings for that context (1 SELECT query), then each subsequent write performs a separate
    INSERT or UPDATE. While `DatabaseHandler` and `FileHandler` use an in-memory cache to maintain fast reads, individual write
-   operations may result in multiple database queries or file writes per request.
+   operations may result in multiple database queries or file writes per request. Use `setMany()` or `forgetMany()` when you
+   want to explicitly persist multiple settings in one batch operation.
 
 2. **Deferred writes (`deferWrites => true`)**: All settings are batched and written to storage at the end of the request
    (during the `post_system` event). This minimizes the number of database queries and file writes, improving performance.

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -36,6 +36,21 @@ abstract class BaseHandler
     }
 
     /**
+     * If the Handler supports saving values, it MAY override this method
+     * to provide optimized batch functionality.
+     *
+     * @param list<array{class: string, property: string, value: mixed}> $settings
+     *
+     * @throws RuntimeException
+     */
+    public function setMany(array $settings, ?string $context = null): void
+    {
+        foreach ($settings as $setting) {
+            $this->set($setting['class'], $setting['property'], $setting['value'], $context);
+        }
+    }
+
+    /**
      * If the Handler supports forgetting values, it
      * MUST override this method to provide that functionality.
      * Not all Handlers will support writing values.
@@ -46,6 +61,21 @@ abstract class BaseHandler
     public function forget(string $class, string $property, ?string $context = null): void
     {
         throw new RuntimeException('Forget method not implemented for current Settings handler.');
+    }
+
+    /**
+     * If the Handler supports forgetting values, it MAY override this method
+     * to provide optimized batch functionality.
+     *
+     * @param list<array{class: string, property: string}> $settings
+     *
+     * @throws RuntimeException
+     */
+    public function forgetMany(array $settings, ?string $context = null): void
+    {
+        foreach ($settings as $setting) {
+            $this->forget($setting['class'], $setting['property'], $context);
+        }
     }
 
     /**

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -386,6 +386,10 @@ class DatabaseHandler extends ArrayHandler
      */
     private function persistRows(array $upserts, array $deletes): void
     {
+        if ($upserts === [] && $deletes === []) {
+            return;
+        }
+
         $this->db->transStart();
 
         // Handle upserts: fetch existing records matching our pending data

--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -91,6 +91,35 @@ class DatabaseHandler extends ArrayHandler
     }
 
     /**
+     * Stores multiple values into the database for later retrieval.
+     *
+     * @param list<array{class: string, property: string, value: mixed}> $settings
+     *
+     * @throws RuntimeException For database failures
+     */
+    public function setMany(array $settings, ?string $context = null): void
+    {
+        if ($settings === []) {
+            return;
+        }
+
+        if ($this->deferWrites) {
+            foreach ($settings as $setting) {
+                $this->markPending($setting['class'], $setting['property'], $setting['value'], $context);
+                $this->setStored($setting['class'], $setting['property'], $setting['value'], $context);
+            }
+
+            return;
+        }
+
+        $this->persistRows($this->prepareUpsertRows($settings, $context), []);
+
+        foreach ($settings as $setting) {
+            $this->setStored($setting['class'], $setting['property'], $setting['value'], $context);
+        }
+    }
+
+    /**
      * Persists a single property to the database.
      *
      * @param mixed $value
@@ -150,6 +179,36 @@ class DatabaseHandler extends ArrayHandler
 
         // Delete from local storage
         $this->forgetStored($class, $property, $context);
+    }
+
+    /**
+     * Deletes multiple records from persistent storage, if found,
+     * and from the local cache.
+     *
+     * @param list<array{class: string, property: string}> $settings
+     */
+    public function forgetMany(array $settings, ?string $context = null): void
+    {
+        if ($settings === []) {
+            return;
+        }
+
+        $this->hydrate($context);
+
+        if ($this->deferWrites) {
+            foreach ($settings as $setting) {
+                $this->markPending($setting['class'], $setting['property'], null, $context, true);
+                $this->forgetStored($setting['class'], $setting['property'], $context);
+            }
+
+            return;
+        }
+
+        $this->persistRows([], $this->prepareDeleteRows($settings, $context));
+
+        foreach ($settings as $setting) {
+            $this->forgetStored($setting['class'], $setting['property'], $context);
+        }
     }
 
     /**
@@ -260,73 +319,133 @@ class DatabaseHandler extends ArrayHandler
         }
 
         try {
-            $this->db->transStart();
-
-            // Handle upserts: fetch existing records matching our pending data
-            if ($upserts !== []) {
-                // Build query to fetch only the specific records we need
-                $this->buildOrWhereConditions($upserts, 'class', 'key', 'context');
-
-                $existing = $this->builder->get()->getResultArray();
-
-                // Build a map of existing records for quick lookup
-                $existingMap = [];
-
-                foreach ($existing as $row) {
-                    $key               = $this->buildCompositeKey($row['class'], $row['key'], $row['context']);
-                    $existingMap[$key] = $row['id'];
-                }
-
-                // Separate into inserts and updates
-                $inserts = [];
-                $updates = [];
-
-                foreach ($upserts as $row) {
-                    $key = $this->buildCompositeKey($row['class'], $row['key'], $row['context']);
-
-                    if (isset($existingMap[$key])) {
-                        // Record exists - prepare for update
-                        $updates[] = [
-                            'id'         => $existingMap[$key],
-                            'value'      => $row['value'],
-                            'type'       => $row['type'],
-                            'updated_at' => $row['updated_at'],
-                        ];
-                    } else {
-                        // New record - prepare for insert
-                        $inserts[] = $row;
-                    }
-                }
-
-                // Batch insert new records
-                if ($inserts !== []) {
-                    $this->builder->insertBatch($inserts);
-                }
-
-                // Batch update existing records
-                if ($updates !== []) {
-                    $this->builder->updateBatch($updates, 'id');
-                }
-            }
-
-            // Batch delete all delete operations
-            if ($deletes !== []) {
-                $this->buildOrWhereConditions($deletes, 'class', 'key', 'context');
-
-                $this->builder->delete();
-            }
-
-            $this->db->transComplete();
-
-            if ($this->db->transStatus() === false) {
-                log_message('error', 'Failed to persist pending properties to database.');
-            }
+            $this->persistRows($upserts, $deletes);
 
             $this->pendingProperties = [];
-        } catch (DatabaseException $e) {
+        } catch (DatabaseException|RuntimeException $e) {
             log_message('error', 'Failed to persist pending properties: ' . $e->getMessage());
 
             $this->pendingProperties = [];
+        }
+    }
+
+    /**
+     * Prepares database rows for setting persistence.
+     *
+     * @param list<array{class: string, property: string, value: mixed}> $settings
+     *
+     * @return list<array{class: string, key: string, value: mixed, type: string, context: string|null, created_at: string, updated_at: string}>
+     */
+    private function prepareUpsertRows(array $settings, ?string $context): array
+    {
+        $time = Time::now()->format('Y-m-d H:i:s');
+        $rows = [];
+
+        foreach ($settings as $setting) {
+            $rows[] = [
+                'class'      => $setting['class'],
+                'key'        => $setting['property'],
+                'value'      => $this->prepareValue($setting['value']),
+                'type'       => gettype($setting['value']),
+                'context'    => $context,
+                'created_at' => $time,
+                'updated_at' => $time,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Prepares database rows for delete persistence.
+     *
+     * @param list<array{class: string, property: string}> $settings
+     *
+     * @return list<array{class: string, key: string, context: string|null}>
+     */
+    private function prepareDeleteRows(array $settings, ?string $context): array
+    {
+        $rows = [];
+
+        foreach ($settings as $setting) {
+            $rows[] = [
+                'class'   => $setting['class'],
+                'key'     => $setting['property'],
+                'context' => $context,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Persists prepared rows to the database.
+     *
+     * @param list<array{class: string, key: string, value: mixed, type: string, context: string|null, created_at: string, updated_at: string}> $upserts
+     * @param list<array{class: string, key: string, context: string|null}>                                                                     $deletes
+     */
+    private function persistRows(array $upserts, array $deletes): void
+    {
+        $this->db->transStart();
+
+        // Handle upserts: fetch existing records matching our pending data
+        if ($upserts !== []) {
+            // Build query to fetch only the specific records we need
+            $this->buildOrWhereConditions($upserts, 'class', 'key', 'context');
+
+            $existing = $this->builder->get()->getResultArray();
+
+            // Build a map of existing records for quick lookup
+            $existingMap = [];
+
+            foreach ($existing as $row) {
+                $key               = $this->buildCompositeKey($row['class'], $row['key'], $row['context']);
+                $existingMap[$key] = $row['id'];
+            }
+
+            // Separate into inserts and updates
+            $inserts = [];
+            $updates = [];
+
+            foreach ($upserts as $row) {
+                $key = $this->buildCompositeKey($row['class'], $row['key'], $row['context']);
+
+                if (isset($existingMap[$key])) {
+                    // Record exists - prepare for update
+                    $updates[] = [
+                        'id'         => $existingMap[$key],
+                        'value'      => $row['value'],
+                        'type'       => $row['type'],
+                        'updated_at' => $row['updated_at'],
+                    ];
+                } else {
+                    // New record - prepare for insert
+                    $inserts[] = $row;
+                }
+            }
+
+            // Batch insert new records
+            if ($inserts !== []) {
+                $this->builder->insertBatch($inserts);
+            }
+
+            // Batch update existing records
+            if ($updates !== []) {
+                $this->builder->updateBatch($updates, 'id');
+            }
+        }
+
+        // Batch delete all delete operations
+        if ($deletes !== []) {
+            $this->buildOrWhereConditions($deletes, 'class', 'key', 'context');
+
+            $this->builder->delete();
+        }
+
+        $this->db->transComplete();
+
+        if ($this->db->transStatus() === false) {
+            throw new RuntimeException('Failed to persist settings to database.');
         }
     }
 

--- a/src/Handlers/FileHandler.php
+++ b/src/Handlers/FileHandler.php
@@ -98,6 +98,45 @@ class FileHandler extends ArrayHandler
     }
 
     /**
+     * Stores multiple values into files for later retrieval.
+     *
+     * @param list<array{class: string, property: string, value: mixed}> $settings
+     *
+     * @throws RuntimeException For file write failures
+     */
+    public function setMany(array $settings, ?string $context = null): void
+    {
+        if ($settings === []) {
+            return;
+        }
+
+        $changesByClass = [];
+
+        foreach ($settings as $setting) {
+            $this->hydrate($setting['class'], $context);
+            $this->setStored($setting['class'], $setting['property'], $setting['value'], $context);
+
+            if ($this->deferWrites) {
+                $this->markPending($setting['class'], $setting['property'], $setting['value'], $context);
+            } else {
+                $changesByClass[$setting['class']][] = [
+                    'property' => $setting['property'],
+                    'value'    => $setting['value'],
+                    'delete'   => false,
+                ];
+            }
+        }
+
+        if ($this->deferWrites) {
+            return;
+        }
+
+        foreach ($changesByClass as $class => $changes) {
+            $this->persist($class, $context, $changes);
+        }
+    }
+
+    /**
      * Deletes the record from persistent storage, if found,
      * and from the local cache.
      *
@@ -119,6 +158,46 @@ class FileHandler extends ArrayHandler
                 'value'    => null,
                 'delete'   => true,
             ]]);
+        }
+    }
+
+    /**
+     * Deletes multiple records from persistent storage, if found,
+     * and from the local cache.
+     *
+     * @param list<array{class: string, property: string}> $settings
+     *
+     * @throws RuntimeException For file write failures
+     */
+    public function forgetMany(array $settings, ?string $context = null): void
+    {
+        if ($settings === []) {
+            return;
+        }
+
+        $changesByClass = [];
+
+        foreach ($settings as $setting) {
+            $this->hydrate($setting['class'], $context);
+            $this->forgetStored($setting['class'], $setting['property'], $context);
+
+            if ($this->deferWrites) {
+                $this->markPending($setting['class'], $setting['property'], null, $context, true);
+            } else {
+                $changesByClass[$setting['class']][] = [
+                    'property' => $setting['property'],
+                    'value'    => null,
+                    'delete'   => true,
+                ];
+            }
+        }
+
+        if ($this->deferWrites) {
+            return;
+        }
+
+        foreach ($changesByClass as $class => $changes) {
+            $this->persist($class, $context, $changes);
         }
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -87,6 +87,36 @@ class Settings
     }
 
     /**
+     * Save multiple values to the writable handler for later retrieval.
+     *
+     * @param array<string, mixed> $settings
+     */
+    public function setMany(array $settings, ?string $context = null): void
+    {
+        if ($settings === []) {
+            return;
+        }
+
+        $prepared = [];
+
+        foreach ($settings as $key => $value) {
+            [$class, $property] = $this->prepareClassAndProperty($key);
+
+            $prepared[$class . '::' . $property] = [
+                'class'    => $class,
+                'property' => $property,
+                'value'    => $value,
+            ];
+        }
+
+        $prepared = array_values($prepared);
+
+        foreach ($this->getWriteHandlers() as $handler) {
+            $handler->setMany($prepared, $context);
+        }
+    }
+
+    /**
      * Removes a setting from the persistent storage,
      * effectively returning the value to the default value
      * found in the config file, if any.
@@ -97,6 +127,37 @@ class Settings
 
         foreach ($this->getWriteHandlers() as $handler) {
             $handler->forget($class, $property, $context);
+        }
+    }
+
+    /**
+     * Removes multiple settings from the persistent storage,
+     * effectively returning the values to the default values
+     * found in the config file, if any.
+     *
+     * @param list<string> $keys
+     */
+    public function forgetMany(array $keys, ?string $context = null): void
+    {
+        if ($keys === []) {
+            return;
+        }
+
+        $prepared = [];
+
+        foreach ($keys as $key) {
+            [$class, $property] = $this->prepareClassAndProperty($key);
+
+            $prepared[$class . '::' . $property] = [
+                'class'    => $class,
+                'property' => $property,
+            ];
+        }
+
+        $prepared = array_values($prepared);
+
+        foreach ($this->getWriteHandlers() as $handler) {
+            $handler->forgetMany($prepared, $context);
         }
     }
 

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -276,6 +276,113 @@ final class DatabaseHandlerTest extends TestCase
         ]);
     }
 
+    public function testSetManyInsertsNewRows(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'    => 'BatchName',
+            'Example.siteEmail'   => 'batch@example.com',
+            'Example.siteTitle'   => 'BatchTitle',
+            'Example.siteEnabled' => true,
+        ]);
+
+        foreach ([
+            ['key' => 'siteName', 'value' => 'BatchName', 'type' => 'string'],
+            ['key' => 'siteEmail', 'value' => 'batch@example.com', 'type' => 'string'],
+            ['key' => 'siteTitle', 'value' => 'BatchTitle', 'type' => 'string'],
+            ['key' => 'siteEnabled', 'value' => '1', 'type' => 'boolean'],
+        ] as $expected) {
+            $this->seeInDatabase($this->table, [
+                'class' => 'Tests\Support\Config\Example',
+                'key'   => $expected['key'],
+                'value' => $expected['value'],
+                'type'  => $expected['type'],
+            ]);
+        }
+    }
+
+    public function testSetManyUpdatesExistingRowsWithoutDuplicates(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'InitialName',
+            'Example.siteEmail' => 'initial@example.com',
+        ]);
+
+        $this->settings->setMany([
+            'Example.siteName'  => 'UpdatedName',
+            'Example.siteEmail' => 'updated@example.com',
+            'Example.siteTitle' => 'NewTitle',
+        ]);
+
+        $totalCount = $this->db->table($this->table)
+            ->where('class', 'Tests\Support\Config\Example')
+            ->countAllResults();
+
+        $this->assertSame(3, $totalCount);
+
+        foreach ([
+            'siteName'  => 'UpdatedName',
+            'siteEmail' => 'updated@example.com',
+            'siteTitle' => 'NewTitle',
+        ] as $key => $value) {
+            $this->seeInDatabase($this->table, [
+                'class' => 'Tests\Support\Config\Example',
+                'key'   => $key,
+                'value' => $value,
+            ]);
+        }
+    }
+
+    public function testSetManyWithContext(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'ContextName',
+            'Example.siteEmail' => 'context@example.com',
+        ], 'environment:test');
+
+        $this->seeInDatabase($this->table, [
+            'class'   => 'Tests\Support\Config\Example',
+            'key'     => 'siteName',
+            'value'   => 'ContextName',
+            'context' => 'environment:test',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class'   => 'Tests\Support\Config\Example',
+            'key'     => 'siteEmail',
+            'value'   => 'context@example.com',
+            'context' => 'environment:test',
+        ]);
+
+        $this->assertSame('ContextName', $this->settings->get('Example.siteName', 'environment:test'));
+    }
+
+    public function testForgetManyDeletesRows(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+            'Example.siteTitle' => 'BatchTitle',
+        ]);
+
+        $this->settings->forgetMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteEmail',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteTitle',
+            'value' => 'BatchTitle',
+        ]);
+    }
+
     /**
      * @see https://github.com/codeigniter4/settings/issues/20
      */
@@ -307,6 +414,73 @@ final class DatabaseHandlerTest extends TestCase
             'value'   => 'Jack',
             'type'    => 'string',
             'context' => 'context:male',
+        ]);
+    }
+
+    public function testDeferredSetManyPersistsAfterPersist(): void
+    {
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName'  => 'DeferredName',
+            'Example.siteEmail' => 'deferred@example.com',
+        ]);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteEmail',
+        ]);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+            'value' => 'DeferredName',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteEmail',
+            'value' => 'deferred@example.com',
+        ]);
+    }
+
+    public function testDeferredForgetManyDeletesAfterPersist(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ]);
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->forgetMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]);
+
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteEmail',
+        ]);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteEmail',
         ]);
     }
 

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -355,6 +355,25 @@ final class DatabaseHandlerTest extends TestCase
         $this->assertSame('ContextName', $this->settings->get('Example.siteName', 'environment:test'));
     }
 
+    public function testSetManyStoresDifferentClasses(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+            'value' => 'BatchName',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
+            'value' => 'NadaName',
+        ]);
+    }
+
     public function testForgetManyDeletesRows(): void
     {
         $this->settings->setMany([
@@ -380,6 +399,28 @@ final class DatabaseHandlerTest extends TestCase
             'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteTitle',
             'value' => 'BatchTitle',
+        ]);
+    }
+
+    public function testForgetManyDeletesDifferentClasses(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $this->settings->forgetMany([
+            'Example.siteName',
+            'Nada.siteName',
+        ]);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
         ]);
     }
 
@@ -449,6 +490,38 @@ final class DatabaseHandlerTest extends TestCase
         ]);
     }
 
+    public function testDeferredSetManyPersistsDifferentClassesAfterPersist(): void
+    {
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName' => 'DeferredName',
+            'Nada.siteName'    => 'DeferredNada',
+        ]);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
+        ]);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+            'value' => 'DeferredName',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
+            'value' => 'DeferredNada',
+        ]);
+    }
+
     public function testDeferredForgetManyDeletesAfterPersist(): void
     {
         $this->settings->setMany([
@@ -481,6 +554,41 @@ final class DatabaseHandlerTest extends TestCase
         $this->dontSeeInDatabase($this->table, [
             'class' => 'Tests\Support\Config\Example',
             'key'   => 'siteEmail',
+        ]);
+    }
+
+    public function testDeferredForgetManyDeletesDifferentClassesAfterPersist(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->forgetMany([
+            'Example.siteName',
+            'Nada.siteName',
+        ]);
+
+        $this->seeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->seeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
+        ]);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Tests\Support\Config\Example',
+            'key'   => 'siteName',
+        ]);
+        $this->dontSeeInDatabase($this->table, [
+            'class' => 'Nada',
+            'key'   => 'siteName',
         ]);
     }
 

--- a/tests/FileHandlerTest.php
+++ b/tests/FileHandlerTest.php
@@ -285,6 +285,67 @@ final class FileHandlerTest extends TestCase
         $this->assertCount(1, $files);
     }
 
+    public function testSetManyStoresMultiplePropertiesInSameFile(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+            'Example.siteTitle' => 'BatchTitle',
+        ]);
+
+        $this->assertSame('BatchName', $this->settings->get('Example.siteName'));
+        $this->assertSame('batch@example.com', $this->settings->get('Example.siteEmail'));
+        $this->assertSame('BatchTitle', $this->settings->get('Example.siteTitle'));
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertCount(1, $files);
+    }
+
+    public function testSetManyStoresDifferentClassesInDifferentFiles(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $this->assertSame('BatchName', $this->settings->get('Example.siteName'));
+        $this->assertSame('NadaName', $this->settings->get('Nada.siteName'));
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertCount(2, $files);
+    }
+
+    public function testSetManyWithContext(): void
+    {
+        $context = 'environment:production';
+
+        $this->settings->setMany([
+            'Example.siteName'  => 'ContextName',
+            'Example.siteEmail' => 'context@example.com',
+        ], $context);
+
+        $this->assertSame('ContextName', $this->settings->get('Example.siteName', $context));
+        $this->assertSame('context@example.com', $this->settings->get('Example.siteEmail', $context));
+    }
+
+    public function testForgetManyRemovesMultipleProperties(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+            'Example.siteTitle' => 'BatchTitle',
+        ]);
+
+        $this->settings->forgetMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]);
+
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
+        $this->assertNull($this->settings->get('Example.siteEmail'));
+        $this->assertSame('BatchTitle', $this->settings->get('Example.siteTitle'));
+    }
+
     public function testDifferentClassesCreateDifferentFiles(): void
     {
         $this->settings->set('Example.siteName', 'Foo');
@@ -567,5 +628,55 @@ final class FileHandlerTest extends TestCase
         $data = include $files[0];
         $this->assertArrayHasKey('siteName', $data);
         $this->assertSame('NewValue', $data['siteName']['value']);
+    }
+
+    public function testDeferredSetManyPersistsAfterPersist(): void
+    {
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName'  => 'DeferredName',
+            'Example.siteEmail' => 'deferred@example.com',
+        ]);
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertEmpty($files);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertCount(1, $files);
+
+        $data = include $files[0];
+        $this->assertSame('DeferredName', $data['siteName']['value']);
+        $this->assertSame('deferred@example.com', $data['siteEmail']['value']);
+    }
+
+    public function testDeferredForgetManyDeletesAfterPersist(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ]);
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertCount(1, $files);
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->forgetMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]);
+
+        $data = include $files[0];
+        $this->assertArrayHasKey('siteName', $data);
+        $this->assertArrayHasKey('siteEmail', $data);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $data = include $files[0];
+        $this->assertArrayNotHasKey('siteName', $data);
+        $this->assertArrayNotHasKey('siteEmail', $data);
     }
 }

--- a/tests/FileHandlerTest.php
+++ b/tests/FileHandlerTest.php
@@ -69,6 +69,20 @@ final class FileHandlerTest extends TestCase
     }
 
     /**
+     * Creates a new Settings instance for reading persisted file values.
+     */
+    private function createSettings(): Settings
+    {
+        /** @var ConfigSettings $config */
+        $config                      = config('Settings');
+        $config->handlers            = ['file'];
+        $config->file['path']        = $this->path;
+        $config->file['deferWrites'] = false;
+
+        return new Settings($config);
+    }
+
+    /**
      * Manually triggers deferred writes for a Settings instance.
      */
     private function persistDeferredWrites(Settings $settings): void
@@ -344,6 +358,22 @@ final class FileHandlerTest extends TestCase
         $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
         $this->assertNull($this->settings->get('Example.siteEmail'));
         $this->assertSame('BatchTitle', $this->settings->get('Example.siteTitle'));
+    }
+
+    public function testForgetManyRemovesDifferentClasses(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $this->settings->forgetMany([
+            'Example.siteName',
+            'Nada.siteName',
+        ]);
+
+        $this->assertSame('Settings Test', $this->settings->get('Example.siteName'));
+        $this->assertNull($this->settings->get('Nada.siteName'));
     }
 
     public function testDifferentClassesCreateDifferentFiles(): void
@@ -652,6 +682,26 @@ final class FileHandlerTest extends TestCase
         $this->assertSame('deferred@example.com', $data['siteEmail']['value']);
     }
 
+    public function testDeferredSetManyPersistsDifferentClassesAfterPersist(): void
+    {
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName' => 'DeferredName',
+            'Nada.siteName'    => 'DeferredNada',
+        ]);
+
+        $files = glob($this->path . '*.php', GLOB_NOSORT);
+        $this->assertEmpty($files);
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $settings = $this->createSettings();
+
+        $this->assertSame('DeferredName', $settings->get('Example.siteName'));
+        $this->assertSame('DeferredNada', $settings->get('Nada.siteName'));
+    }
+
     public function testDeferredForgetManyDeletesAfterPersist(): void
     {
         $this->settings->setMany([
@@ -678,5 +728,30 @@ final class FileHandlerTest extends TestCase
         $data = include $files[0];
         $this->assertArrayNotHasKey('siteName', $data);
         $this->assertArrayNotHasKey('siteEmail', $data);
+    }
+
+    public function testDeferredForgetManyDeletesDifferentClassesAfterPersist(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName' => 'BatchName',
+            'Nada.siteName'    => 'NadaName',
+        ]);
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->forgetMany([
+            'Example.siteName',
+            'Nada.siteName',
+        ]);
+
+        $this->assertSame('BatchName', $this->settings->get('Example.siteName'));
+        $this->assertSame('NadaName', $this->settings->get('Nada.siteName'));
+
+        $this->persistDeferredWrites($deferredSettings);
+
+        $settings = $this->createSettings();
+
+        $this->assertSame('Settings Test', $settings->get('Example.siteName'));
+        $this->assertNull($settings->get('Nada.siteName'));
     }
 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use CodeIgniter\Settings\Settings;
 use Config\Services;
+use Tests\Support\Config\Example;
 use Tests\Support\TestCase;
 
 /**
@@ -56,6 +57,39 @@ final class SettingsTest extends TestCase
         $this->assertSame('YesContext', $this->settings->get('Example.siteName', 'testing:true'));
     }
 
+    public function testSetManyStoresMultipleValues(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ]);
+
+        $this->assertSame('BatchName', $this->settings->get('Example.siteName'));
+        $this->assertSame('batch@example.com', $this->settings->get('Example.siteEmail'));
+    }
+
+    public function testSetManyWithContext(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ], 'testing:true');
+
+        $this->assertSame(config('Example')->siteName, $this->settings->get('Example.siteName'));
+        $this->assertSame('BatchName', $this->settings->get('Example.siteName', 'testing:true'));
+        $this->assertSame('batch@example.com', $this->settings->get('Example.siteEmail', 'testing:true'));
+    }
+
+    public function testSetManyUsesLastNormalizedKey(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'           => 'ShortName',
+            Example::class . '.siteName' => 'FullName',
+        ]);
+
+        $this->assertSame('FullName', $this->settings->get('Example.siteName'));
+    }
+
     public function testGetWithoutContextUsesGlobal(): void
     {
         $this->settings->set('Example.siteName', 'NoContext');
@@ -71,5 +105,21 @@ final class SettingsTest extends TestCase
         $this->settings->forget('Example.siteName', 'category:disease');
 
         $this->assertSame('Bar', $this->settings->get('Example.siteName', 'category:disease'));
+    }
+
+    public function testForgetManyRemovesMultipleValues(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ]);
+
+        $this->settings->forgetMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]);
+
+        $this->assertSame(config('Example')->siteName, $this->settings->get('Example.siteName'));
+        $this->assertNull($this->settings->get('Example.siteEmail'));
     }
 }

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -90,6 +90,16 @@ final class SettingsTest extends TestCase
         $this->assertSame('FullName', $this->settings->get('Example.siteName'));
     }
 
+    public function testBatchMethodsAcceptEmptyArrays(): void
+    {
+        $this->settings->set('Example.siteName', 'ExistingName');
+
+        $this->settings->setMany([]);
+        $this->settings->forgetMany([]);
+
+        $this->assertSame('ExistingName', $this->settings->get('Example.siteName'));
+    }
+
     public function testGetWithoutContextUsesGlobal(): void
     {
         $this->settings->set('Example.siteName', 'NoContext');


### PR DESCRIPTION
**Description**
Hello! This PR proposes adding explicit batch APIs for storing and forgetting multiple settings in one call:

- `Settings::setMany()`
- `Settings::forgetMany()`

This is offered as a small, generic addition for maintainers to review and adjust. The goal is to support applications and modules that already have a related group of settings to update, without requiring callers to issue separate `set()` or `forget()` calls for each item.

This can be useful for common cases like saving configuration forms, applying setup defaults, updating module preferences, importing settings, or resetting a group of related options. It also gives handlers a clear extension point for optimizing grouped writes while keeping existing handler behavior compatible.

**Why**

The limitations documentation notes that immediate writes can result in multiple database queries or file writes when several settings are changed in one request.

With this PR, callers can group those operations directly:

```php
service('settings')->setMany([
    'App.siteName'  => 'My Great Site',
    'App.siteEmail' => 'support@example.com',
]);

service('settings')->forgetMany([
    'App.siteName',
    'App.siteEmail',
]);
```

This is also intended to complement the deferred writes work from #154. Deferred writes optimize multiple `set()` / `forget()` calls across the request lifecycle, while these methods provide an explicit API when the caller already has a batch of related changes.

**Behavior**

The new APIs follow the same behavior as repeated calls to `set()` and `forget()`:

- keys use the existing `Class.property` syntax
- contexts work the same way
- config fallback behavior is unchanged
- duplicate keys resolve consistently, with the last value winning
- no database schema changes are required

They also respect the current `deferWrites` setting:

- when `deferWrites` is disabled, supported handlers persist the batch immediately
- when `deferWrites` is enabled, batch calls are queued and persisted during `post_system`

**Handler Support**

`BaseHandler` includes default `setMany()` and `forgetMany()` implementations that call the existing `set()` and `forget()` methods for each item. Existing custom handlers keep working through this fallback.

Handlers can still override the batch methods when they can persist more efficiently:

- `DatabaseHandler` groups batch inserts, updates, and deletes
- `FileHandler` groups changes per class/context file

**Tests and Docs**

This PR adds tests for the public API, context-aware batch operations, duplicate key handling, database/file handler batch persistence, and deferred batch writes.

The user guide is updated with examples and clarifies how explicit batch APIs relate to deferred writes.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
