### PR TITLE
fix(database): hydrate deferred writes before staging values

### DIFF
--- a/src/Handlers/DatabaseHandler.php
+++ b/src/Handlers/DatabaseHandler.php
@@ -81,6 +81,7 @@ class DatabaseHandler extends ArrayHandler
     public function set(string $class, string $property, $value = null, ?string $context = null): void
     {
         if ($this->deferWrites) {
+            $this->hydrate($context);
             $this->markPending($class, $property, $value, $context);
         } else {
             $this->persist($class, $property, $value, $context);
@@ -104,6 +105,8 @@ class DatabaseHandler extends ArrayHandler
         }
 
         if ($this->deferWrites) {
+            $this->hydrate($context);
+
             foreach ($settings as $setting) {
                 $this->markPending($setting['class'], $setting['property'], $setting['value'], $context);
                 $this->setStored($setting['class'], $setting['property'], $setting['value'], $context);

--- a/tests/DatabaseHandlerTest.php
+++ b/tests/DatabaseHandlerTest.php
@@ -490,6 +490,30 @@ final class DatabaseHandlerTest extends TestCase
         ]);
     }
 
+    public function testDeferredSetReturnsPendingValueBeforePersist(): void
+    {
+        $this->settings->set('Example.siteName', 'StoredSingle');
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->set('Example.siteName', 'PendingSingle');
+
+        $this->assertSame('PendingSingle', $deferredSettings->get('Example.siteName'));
+    }
+
+    public function testDeferredSetManyReturnsPendingValueBeforePersist(): void
+    {
+        $this->settings->set('Example.siteName', 'StoredBatch');
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName' => 'PendingBatch',
+        ]);
+
+        $this->assertSame('PendingBatch', $deferredSettings->get('Example.siteName'));
+    }
+
     public function testDeferredSetManyPersistsDifferentClassesAfterPersist(): void
     {
         $deferredSettings = $this->createDeferredSettings();

--- a/tests/FileHandlerTest.php
+++ b/tests/FileHandlerTest.php
@@ -682,6 +682,30 @@ final class FileHandlerTest extends TestCase
         $this->assertSame('deferred@example.com', $data['siteEmail']['value']);
     }
 
+    public function testDeferredSetReturnsPendingValueBeforePersist(): void
+    {
+        $this->settings->set('Example.siteName', 'FileStoredSingle');
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->set('Example.siteName', 'FilePendingSingle');
+
+        $this->assertSame('FilePendingSingle', $deferredSettings->get('Example.siteName'));
+    }
+
+    public function testDeferredSetManyReturnsPendingValueBeforePersist(): void
+    {
+        $this->settings->set('Example.siteName', 'FileStoredBatch');
+
+        $deferredSettings = $this->createDeferredSettings();
+
+        $deferredSettings->setMany([
+            'Example.siteName' => 'FilePendingBatch',
+        ]);
+
+        $this->assertSame('FilePendingBatch', $deferredSettings->get('Example.siteName'));
+    }
+
     public function testDeferredSetManyPersistsDifferentClassesAfterPersist(): void
     {
         $deferredSettings = $this->createDeferredSettings();


### PR DESCRIPTION
**Description**
This PR fixes deferred database writes so `get()` returns the pending value after `set()` or `setMany()` in the same request.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
