### PR TITLE
feat: add `getMany()` settings API

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -15,6 +15,15 @@ To retrieve a config value use the `settings` service.
 $siteName = service('settings')->get('App.siteName');
 ```
 
+You can retrieve multiple values with `getMany()`. This behaves like calling `get()` for each key.
+
+```php
+$settings = service('settings')->getMany([
+    'App.siteName',
+    'App.siteEmail',
+]);
+```
+
 In this case we used the short class name, `App`, which the `config()` method automatically locates within the
 `app/Config` directory. If it was from a module, it would be found there. Either way, the fully qualified name
 is automatically detected by the Settings class to keep values separated from config files that may share the
@@ -119,6 +128,10 @@ setting('App.siteName', 'My Great Site');
 
 // Using the service through the helper
 $name = setting()->get('App.siteName');
+$settings = setting()->getMany([
+    'App.siteName',
+    'App.siteEmail',
+]);
 setting()->set('App.siteName', 'My Great Site');
 setting()->setMany([
     'App.siteName'  => 'My Great Site',

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -24,6 +24,8 @@ $settings = service('settings')->getMany([
 ]);
 ```
 
+Unlike `get()`, which returns a single value, `getMany()` returns an array keyed by the exact setting names you requested.
+
 In this case we used the short class name, `App`, which the `config()` method automatically locates within the
 `app/Config` directory. If it was from a module, it would be found there. Either way, the fully qualified name
 is automatically detected by the Settings class to keep values separated from config files that may share the

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -73,6 +73,24 @@ class Settings
     }
 
     /**
+     * Retrieve multiple values using the same behavior as get().
+     *
+     * @param list<string> $keys
+     *
+     * @return array<string, mixed>
+     */
+    public function getMany(array $keys, ?string $context = null): array
+    {
+        $settings = [];
+
+        foreach ($keys as $key) {
+            $settings[$key] = $this->get($key, $context);
+        }
+
+        return $settings;
+    }
+
+    /**
      * Save a value to the writable handler for later retrieval.
      *
      * @param mixed $value

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -57,6 +57,70 @@ final class SettingsTest extends TestCase
         $this->assertSame('YesContext', $this->settings->get('Example.siteName', 'testing:true'));
     }
 
+    public function testGetManyReturnsMultipleValues(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ]);
+
+        $this->assertSame([
+            'Example.siteName'  => 'BatchName',
+            'Example.siteEmail' => 'batch@example.com',
+        ], $this->settings->getMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]));
+    }
+
+    public function testGetManyFallsBackToConfigValues(): void
+    {
+        $this->assertSame([
+            'Example.siteName'  => 'Settings Test',
+            'Example.siteEmail' => null,
+        ], $this->settings->getMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ]));
+    }
+
+    public function testGetManyWithContext(): void
+    {
+        $this->settings->setMany([
+            'Example.siteName'  => 'NoContext',
+            'Example.siteEmail' => 'general@example.com',
+        ]);
+        $this->settings->setMany([
+            'Example.siteName' => 'YesContext',
+        ], 'testing:true');
+
+        $this->assertSame([
+            'Example.siteName'  => 'YesContext',
+            'Example.siteEmail' => 'general@example.com',
+        ], $this->settings->getMany([
+            'Example.siteName',
+            'Example.siteEmail',
+        ], 'testing:true'));
+    }
+
+    public function testGetManyPreservesRequestedKeys(): void
+    {
+        $this->settings->set('Example.siteName', 'BatchName');
+
+        $this->assertSame([
+            Example::class . '.siteName' => 'BatchName',
+            'Nada.siteName'              => null,
+        ], $this->settings->getMany([
+            Example::class . '.siteName',
+            'Nada.siteName',
+        ]));
+    }
+
+    public function testGetManyAcceptsEmptyArray(): void
+    {
+        $this->assertSame([], $this->settings->getMany([]));
+    }
+
     public function testSetManyStoresMultipleValues(): void
     {
         $this->settings->setMany([


### PR DESCRIPTION
**Description**
Hello! This PR proposes adding a small `getMany()` convenience API for retrieving multiple settings in one call:

- `Settings::getMany()`

This follows the recently merged batch write APIs from #161, but keeps the read side intentionally simple. The new method behaves like calling `get()` repeatedly for each requested key, while preserving the requested keys in the returned array.

**Why**

Applications and modules often need to read a related group of settings together, such as when preparing configuration forms, loading module preferences, or gathering setup values.

With this PR, callers can group those reads directly:

```php
$settings = service('settings')->getMany([
    'App.siteName',
    'App.siteEmail',
]);
```

This returns:

```php
[
    'App.siteName'  => 'My Great Site',
    'App.siteEmail' => 'support@example.com',
]
```

**Behavior**

`getMany()` follows the same behavior as repeated calls to `get()`:

- keys use the existing `Class.property` syntax
- contexts work the same way
- context fallback behavior is unchanged
- config fallback behavior is unchanged
- missing values return `null`
- returned array keys match the requested keys
- no handler contract changes are required

**Scope**

This PR does not add handler-level batch read methods or optimized read paths. The existing handlers already cache hydrated data, and keeping this first step at the `Settings` API level avoids expanding the handler contract unnecessarily.

**Tests and Docs**

This PR adds tests for stored values, config fallback values, contextual reads, missing values, requested key preservation, and empty input.

The user guide is updated with `getMany()` examples.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
