### PR TITLE
fix: setting value persistence on SQL Server

### DIFF
--- a/src/Database/Migrations/2026-07-20-181246_ConvertSqlsrvValueColumn.php
+++ b/src/Database/Migrations/2026-07-20-181246_ConvertSqlsrvValueColumn.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Settings\Database\Migrations;
+
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Database\Migration;
+use CodeIgniter\Settings\Config\Settings;
+
+class ConvertSqlsrvValueColumn extends Migration
+{
+    private readonly Settings $config;
+
+    public function __construct(?Forge $forge = null)
+    {
+        $this->config  = config('Settings');
+        $this->DBGroup = $this->config->database['group'] ?? null;
+
+        parent::__construct($forge);
+    }
+
+    public function up(): void
+    {
+        if ($this->db->getPlatform() !== 'SQLSRV') {
+            return;
+        }
+
+        $this->forge->modifyColumn($this->config->database['table'], [
+            'value' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 'MAX',
+                'null'       => true,
+            ],
+        ]);
+    }
+
+    public function down(): void
+    {
+        if ($this->db->getPlatform() !== 'SQLSRV') {
+            return;
+        }
+
+        $this->forge->modifyColumn($this->config->database['table'], [
+            'value' => [
+                'type' => 'TEXT',
+                'null' => true,
+            ],
+        ]);
+    }
+}

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -109,7 +109,7 @@ abstract class BaseHandler
     protected function prepareValue($value)
     {
         if (is_bool($value)) {
-            return (int) $value;
+            return $value ? '1' : '0';
         }
 
         if (is_array($value) || is_object($value)) {

--- a/tests/BaseHandlerTest.php
+++ b/tests/BaseHandlerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use CodeIgniter\Settings\Handlers\ArrayHandler;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class BaseHandlerTest extends TestCase
+{
+    public function testPrepareValueSerializesBooleansAsStrings(): void
+    {
+        $prepareValue = self::getPrivateMethodInvoker(new ArrayHandler(), 'prepareValue');
+
+        $this->assertSame('1', $prepareValue(true));
+        $this->assertSame('0', $prepareValue(false));
+    }
+}


### PR DESCRIPTION
**Description**
This PR fixes SQLSRV persistence errors caused by storing setting values in the deprecated `TEXT` column type. For SQLSRV databases, the value column is migrated to `VARCHAR(MAX)` while other database drivers remain unchanged.

Boolean values are now serialized as '1' and '0', preventing mixed-type batch insert failures. Existing stored settings are preserved, and the migration is compatible with SQL Server 2022 and 2025.

Ref:
- https://learn.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver17
- Initial tests run with 2025 version: https://github.com/michalsn/settings/actions/runs/29758096213/job/88405573815
- Test without "serialize boolean" changes: https://github.com/michalsn/settings/actions/runs/29759235767/job/88409396104

Fixes #171

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
